### PR TITLE
Pass per-test options through to the test function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Require in Truffler:
 var truffler = require('truffler');
 ```
 
-Create a test runner by initialising Truffler with a test function. This test function has access to a PhantomJS [browser][phantom-browser] and [page][phantom-page] instance. The test function must accept a third argument which is a callback:
+Create a test runner by initialising Truffler with a test function. This test function has access to a PhantomJS [browser][phantom-browser] and [page][phantom-page] instance, as well as a copy of all the passed in options. The test function must accept a third argument which is a callback:
 
 ```js
-var test = truffler(function(browser, page, done) {
+var test = truffler(function(browser, page, options, done) {
     // ... perform testing here ...
     done(error, results);
 });
@@ -71,7 +71,7 @@ You can also instantiate Truffler with some [default options](#options) if you w
 ```js
 var test = truffler({
     // ... options go here ...
-}, function(browser, page, done) {
+}, function(browser, page, options, done) {
     // ... perform testing here ...
 });
 ```
@@ -87,7 +87,7 @@ test.run('http://www.nature.com/', function(error, results) {
 The `error` and `results` parameters contain errors and results from the PhantomJS run against your page. The results can be any object you like. Here's an example test function which returns the page title if it has one, or errors if not.
 
 ```js
-var test = truffler(function(browser, page, done) {
+var test = truffler(function(browser, page, options, done) {
     page.evaluate(
         function() {
             return document.title;

--- a/example/basic/index.js
+++ b/example/basic/index.js
@@ -13,7 +13,7 @@ var test = truffler({
 	}
 
 // The test function which will get run on URLs
-}, function(browser, page, done) {
+}, function(browser, page, options, done) {
 
 	// Evaluate the page, extract the title, and callback
 	page.evaluate(

--- a/example/multiple/index.js
+++ b/example/multiple/index.js
@@ -14,7 +14,7 @@ var test = truffler({
 	}
 
 // The test function which will get run on URLs
-}, function(browser, page, done) {
+}, function(browser, page, options, done) {
 
 	// Evaluate the page, extract the title, and callback
 	page.evaluate(

--- a/lib/truffler.js
+++ b/lib/truffler.js
@@ -161,7 +161,7 @@ Truffler.prototype._run = function(url, options, done) {
 		// Run the test function
 		runTestFunction: guardAgainstTimeout(function(next) {
 			options.log.info('Testing the page "' + url + '"');
-			state.testFunction(state.browser, state.page, function(error, result) {
+			state.testFunction(state.browser, state.page, options, function(error, result) {
 				if (error) {
 					options.log.error('Test function errored for "' + url + '"');
 					return next(error);

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -11,7 +11,7 @@ describe('Truffler Basic Reporting', function() {
 	before(function(done) {
 
 		// Create a Truffler instance
-		var test = truffler(function(browser, page, completeTest) {
+		var test = truffler(function(browser, page, options, completeTest) {
 			page.evaluate(function() {
 				/* global document */
 				return {

--- a/test/integration/headers.js
+++ b/test/integration/headers.js
@@ -11,7 +11,7 @@ describe('Truffler Custom Headers', function() {
 	before(function(done) {
 
 		// Create a Truffler instance
-		var test = truffler(function(browser, page, completeTest) {
+		var test = truffler(function(browser, page, options, completeTest) {
 			page.evaluate(function() {
 				/* global document */
 				var headers = {};

--- a/test/integration/timeout.js
+++ b/test/integration/timeout.js
@@ -11,7 +11,7 @@ describe('Truffler Timeout', function() {
 	before(function(done) {
 
 		// Create a Truffler instance
-		var test = truffler(function(browser, page, completeTest) {
+		var test = truffler(function(browser, page, options, completeTest) {
 			completeTest();
 		});
 

--- a/test/integration/viewport.js
+++ b/test/integration/viewport.js
@@ -11,7 +11,7 @@ describe('Truffler Custom Viewport', function() {
 	before(function(done) {
 
 		// Create a Truffler instance
-		var test = truffler(function(browser, page, completeTest) {
+		var test = truffler(function(browser, page, options, completeTest) {
 			page.evaluate(function() {
 				/* global window */
 				return {

--- a/test/unit/lib/truffler.js
+++ b/test/unit/lib/truffler.js
@@ -423,10 +423,10 @@ describe('lib/truffler', function() {
 				});
 			});
 
-			it('should run the instance test function, passing in the PhantomJS browser and page', function() {
+			it('should run the instance test function, passing in the PhantomJS browser, page, and options', function() {
 				assert.calledOnce(instance.testFunction);
-				assert.calledWith(instance.testFunction, phantom.mockBrowser, phantom.mockPage);
-				assert.isFunction(instance.testFunction.firstCall.args[2]);
+				assert.calledWith(instance.testFunction, phantom.mockBrowser, phantom.mockPage, options);
+				assert.isFunction(instance.testFunction.firstCall.args[3]);
 			});
 
 			it('should log that the test function is being run', function() {


### PR DESCRIPTION
This is a breaking change, and we'll need to bump major for it. Without
this, Pa11y doesn't actually allow things like beforeScript to be set on
a per-test basis - they'll only work when set for all tests. This isn't
the documented behaviour.