### PR TITLE
Extract the options to a variable

### DIFF
--- a/example/basic/index.js
+++ b/example/basic/index.js
@@ -1,20 +1,17 @@
 'use strict';
 
 var truffler = require('../..');
-
-// Create a test instance with some default options
-var test = truffler({
-
+var options = {
 	// Log what's happening to the console
 	log: {
 		debug: console.log.bind(console),
 		error: console.error.bind(console),
 		info: console.log.bind(console)
 	}
+};
 
-// The test function which will get run on URLs
-}, function(browser, page, options, done) {
-
+// Create a test instance with some default options
+var test = truffler(options, function(browser, page, options, done) {
 	// Evaluate the page, extract the title, and callback
 	page.evaluate(
 		function() {
@@ -25,7 +22,6 @@ var test = truffler({
 			done(null, result);
 		}
 	);
-
 });
 
 // Test http://nature.com/

--- a/example/multiple/index.js
+++ b/example/multiple/index.js
@@ -2,20 +2,17 @@
 
 var async = require('async');
 var truffler = require('../..');
-
-// Create a test instance with some default options
-var test = truffler({
-
+var options = {
 	// Log what's happening to the console
 	log: {
 		debug: console.log.bind(console),
 		error: console.error.bind(console),
 		info: console.log.bind(console)
 	}
+};
 
-// The test function which will get run on URLs
-}, function(browser, page, options, done) {
-
+// Create a test instance with some default options
+var test = truffler(options, function(browser, page, options, done) {
 	// Evaluate the page, extract the title, and callback
 	page.evaluate(
 		function() {
@@ -26,19 +23,16 @@ var test = truffler({
 			done(null, result);
 		}
 	);
-
 });
 
 // Use the async library to run multiple tests in series
 // https://github.com/caolan/async
 async.series({
-
 	// Test the Nature home page
 	home: test.run.bind(test, 'http://nature.com/'),
 
 	// Test the Nature Plants home page
 	plants: test.run.bind(test, 'http://nature.com/nplants/')
-
 }, function(error, results) {
 	if (error) {
 		return console.error(error.message);


### PR DESCRIPTION
Makes the code easier to read but most importantly prevents a
linting error when upgrading to jshint 3 due to the misaligned
comment.