### PR TITLE
Allow all page settings

### DIFF
--- a/lib/truffler.js
+++ b/lib/truffler.js
@@ -146,7 +146,7 @@ Truffler.prototype._run = function (url, options, done) {
 				this.reason = resourceError.errorString;
 			};
 
-			state.page.open(url, function (error, status) {
+			state.page.open(url, options.page.settings, function (error, status) {
 				if (error) {
 					return next(error);
 				}

--- a/test/integration/mock/website/index.js
+++ b/test/integration/mock/website/index.js
@@ -21,6 +21,10 @@ function startMockWebsite(done) {
 			response.end(headers.join('\n'));
 		},
 
+		'/method': function (request, response) {
+			response.end(request.method);
+		},
+
 		'/timeout': function (request, response) {
 			setTimeout(function () {
 				response.end('timeout');

--- a/test/integration/post.js
+++ b/test/integration/post.js
@@ -1,0 +1,39 @@
+// jshint maxstatements: false
+// jscs:disable disallowMultipleVarDecl, maximumLineLength
+'use strict';
+
+var assert = require('proclaim');
+var truffler = require('../..');
+
+describe('Truffler POST request', function () {
+	var testResult;
+
+	before(function (done) {
+		// Create a Truffler instance
+		var test = truffler(function (browser, page, options, completeTest) {
+			page.evaluate(function () {
+				/* global document */
+				return {
+					method: document.body.textContent.replace(/\s+/g, '')
+				};
+			}, completeTest);
+		});
+
+		// Run a test
+		var options = {
+			page: {
+				settings: {
+					operation: 'POST'
+				}
+			}
+		};
+		test.run(this.website.url + '/method', options, function (error, result) {
+			testResult = result;
+			done(error);
+		});
+	});
+
+	it('requests the page with the expected method', function () {
+		assert.strictEqual(testResult.method, 'POST');
+	});
+});

--- a/test/unit/lib/truffler.js
+++ b/test/unit/lib/truffler.js
@@ -395,8 +395,8 @@ describe('lib/truffler', function () {
 
 			it('should open the given URL in the PhantomJS page', function () {
 				assert.calledOnce(phantom.mockPage.open);
-				assert.calledWith(phantom.mockPage.open, url);
-				assert.isFunction(phantom.mockPage.open.firstCall.args[1]);
+				assert.calledWith(phantom.mockPage.open, url, extend.firstCall.returnValue.page.settings);
+				assert.isFunction(phantom.mockPage.open.firstCall.args[2]);
 			});
 
 			it('should log that the URL is being opened', function () {


### PR DESCRIPTION
This enables some PhantomJS page settings that have never worked. The
most obviously useful one is `page.settings.operation` which allows you
to change the request method that Truffler uses.

This resolves #24.